### PR TITLE
feat: Include metadata to persist with files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.common"
-version = "0.2.0"
+version = "0.3.0"
 sourceCompatibility = "11"
 
 configurations {
@@ -50,6 +50,7 @@ dependencies {
   implementation "com.github.javafaker:javafaker:1.0.2"
   implementation "commons-fileupload:commons-fileupload:1.3.1"
   implementation "commons-io:commons-io:2.4"
+  implementation "commons-beanutils:commons-beanutils:1.9.4"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/common/upload/dto/StorageDto.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/dto/StorageDto.java
@@ -2,6 +2,7 @@ package uk.nhs.hee.tis.common.upload.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +19,7 @@ public class StorageDto {
   private String bucketName;
   private String folderPath;
   private String key;
+  private Map<String, String> customMetadata;
   private List<MultipartFile> files;
 
 }

--- a/src/main/java/uk/nhs/hee/tis/common/upload/service/AwsStorageService.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/service/AwsStorageService.java
@@ -38,7 +38,7 @@ public class AwsStorageService {
     try {
       return (String) PropertyUtils.getNestedProperty(o, name);
     } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      log.warn("Couldn't find the sort property [{}] on FileSummary:{}", name, o);
+      log.warn("Couldn't find the sort property [{}] on FileSummary:{}", name, o, e);
       return null;
     }
   }
@@ -125,8 +125,9 @@ public class AwsStorageService {
           .listObjects(storageDto.getBucketName(), storageDto.getFolderPath() + "/");
       var fileSummaryList = listObjects.getObjectSummaries().stream()
           .map(summary -> buildFileSummary(summary, includeMetadata)).collect(toList());
-      String[] sortEntry;
-      if (StringUtils.isNotBlank(sort) && (sortEntry = sort.split(SORT_DELIM)).length < 3) {
+
+      if (StringUtils.isNotBlank(sort) && sort.split(SORT_DELIM).length < 3) {
+        String[] sortEntry = sort.split(SORT_DELIM);
         String sortKey = sortEntry[0];
         String sortDirection = sortEntry[1];
 
@@ -146,7 +147,7 @@ public class AwsStorageService {
       return fileSummaryList;
     } catch (Exception e) {
       log.error("Fail to list files from bucket: {} with folderPath: {}",
-          storageDto.getBucketName(), storageDto.getFolderPath());
+          storageDto.getBucketName(), storageDto.getFolderPath(), e);
       throw new AwsStorageException(e.getMessage());
     }
   }

--- a/src/main/java/uk/nhs/hee/tis/common/upload/service/AwsStorageService.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/service/AwsStorageService.java
@@ -66,7 +66,8 @@ public class AwsStorageService {
         log.info("uploading file: {} to bucket: {} with key: {}", file.getName(), bucketName, key);
         return amazonS3.putObject(request);
       } catch (Exception e) {
-        log.error("Fail to upload file: {} in bucket: {}", file.getOriginalFilename(), bucketName);
+        log.error("Failed to upload file: {} in bucket: {}", file.getOriginalFilename(), bucketName,
+            e);
         throw new AwsStorageException(e.getMessage());
       }
     }).collect(toList());
@@ -90,7 +91,7 @@ public class AwsStorageService {
       return content;
     } catch (Exception e) {
       log.error("Fail to download file: {} from bucket: {}", storageDto.getKey(),
-          storageDto.getBucketName());
+          storageDto.getBucketName(), e);
       throw new AwsStorageException(e.getMessage());
     }
   }
@@ -166,7 +167,7 @@ public class AwsStorageService {
       log.info("File is removed successfully.");
     } catch (Exception e) {
       log.error("Fail to delete file from bucket: {} with key: {}",
-          storageDto.getBucketName(), storageDto.getKey());
+          storageDto.getBucketName(), storageDto.getKey(), e);
       throw new AwsStorageException(e.getMessage());
     }
   }

--- a/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
@@ -190,10 +190,11 @@ public class AwsStorageControllerTest {
         .customMetadata(defaultMetadataMap)
         .fileName(metadataFileName).fileType(metadataFileType).build();
     final var fileSummaryDtoList = List.of(fileSummaryDto);
-    when(storageService.listFiles(any(), eq(false))).thenReturn(fileSummaryDtoList);
+    when(storageService.listFiles(any(), eq(false), eq("interest,highest"))).thenReturn(fileSummaryDtoList);
     mockMvc.perform(get(STORAGE_URL + LIST)
         .param("bucketName", "test-bucket")
-        .param("folderPath", "1/concern"))
+        .param("folderPath", "1/concern")
+        .param("sort", "interest,highest"))
         .andExpect(status().isOk())
         .andExpect(content().string(objectMapper.writeValueAsString(fileSummaryDtoList)));
   }

--- a/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
@@ -21,10 +21,12 @@
 
 package uk.nhs.hee.tis.common.upload.controller;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -97,8 +99,15 @@ public class AwsStorageControllerTest {
     mockMvc.perform(multipart(STORAGE_URL + UPLOAD)
         .file(file)
         .param("bucketName", bucketName)
-        .param("folderPath", folderPath))
+        .param("folderPath", folderPath)
+        .param("customMetadata[key]", "value")
+        .param("customMetadata[uploadDate]", "1992-08-07"))
         .andExpect(status().isOk());
+
+    verify(storageService).upload(storageDtoCaptor.capture());
+    StorageDto expectedDto = StorageDto.builder().bucketName(bucketName).folderPath(folderPath)
+        .files(List.of(file)).customMetadata(Map.of("key", "value", "uploadDate", "1992-08-07")).build();
+    assertThat(storageDtoCaptor.getValue(), equalTo(expectedDto));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
@@ -190,11 +190,12 @@ public class AwsStorageControllerTest {
         .customMetadata(defaultMetadataMap)
         .fileName(metadataFileName).fileType(metadataFileType).build();
     final var fileSummaryDtoList = List.of(fileSummaryDto);
-    when(storageService.listFiles(any(), eq(false), eq("interest,highest"))).thenReturn(fileSummaryDtoList);
+    when(storageService.listFiles(any(), eq(false), eq("interest.score,desc")))
+        .thenReturn(fileSummaryDtoList);
     mockMvc.perform(get(STORAGE_URL + LIST)
         .param("bucketName", "test-bucket")
         .param("folderPath", "1/concern")
-        .param("sort", "interest,highest"))
+        .param("sort", "interest.score,desc"))
         .andExpect(status().isOk())
         .andExpect(content().string(objectMapper.writeValueAsString(fileSummaryDtoList)));
   }

--- a/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageControllerTest.java
@@ -106,7 +106,8 @@ public class AwsStorageControllerTest {
 
     verify(storageService).upload(storageDtoCaptor.capture());
     StorageDto expectedDto = StorageDto.builder().bucketName(bucketName).folderPath(folderPath)
-        .files(List.of(file)).customMetadata(Map.of("key", "value", "uploadDate", "1992-08-07")).build();
+        .customMetadata(Map.of("key", "value", "uploadDate", "1992-08-07"))
+        .files(List.of(file)).build();
     assertThat(storageDtoCaptor.getValue(), equalTo(expectedDto));
   }
 


### PR DESCRIPTION
Save any metadata defined by the client, e.g. "lifecycleState" of a form

TISNEW-5376: Enable TIS Admins to see submitted Form Rs