### PR TITLE
chore: add ECR login before pushing stable tag

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -221,6 +221,10 @@ jobs:
       - name: Deploy Amazon ECS task definition
         run: aws ecs update-service --cluster trainee-preprod --service ${{ github.event.repository.name }} --task-definition ${{ github.event.repository.name }}
 
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
       - name: Push stable tag image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
attempt to fix the missing ECR_REGISTRY issue

TISNEW-5487