### PR TITLE
refactor: upgrade AWS Java SDK to V2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,9 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-validation"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
-  implementation "com.amazonaws:aws-java-sdk-s3:1.12.681"
+  implementation platform('software.amazon.awssdk:bom:2.41.8')
+  implementation 'software.amazon.awssdk:s3'
+  implementation 'software.amazon.awssdk:sns'
   implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging:2.4.4"
 
   // Lombok

--- a/src/main/java/uk/nhs/hee/tis/common/upload/config/AwsS3Config.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/config/AwsS3Config.java
@@ -1,9 +1,8 @@
 package uk.nhs.hee.tis.common.upload.config;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.s3.S3Client;
 
 /**
  * A configuration class for Amazon S3 integration.
@@ -12,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class AwsS3Config {
 
   @Bean
-  public AmazonS3 amazonS3() {
-    return AmazonS3ClientBuilder.defaultClient();
+  public S3Client amazonS3() {
+    return S3Client.create();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/common/upload/config/AwsSnsConfig.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/config/AwsSnsConfig.java
@@ -1,0 +1,17 @@
+package uk.nhs.hee.tis.common.upload.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+/**
+ * A configuration class for AWS SNS client.
+ */
+@Configuration
+public class AwsSnsConfig {
+
+  @Bean
+  public SnsClient snsClient() {
+    return SnsClient.create();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
@@ -37,13 +37,13 @@ public class AwsStorageController {
    * @return Response entity with status code 200
    */
   @PostMapping(value = "/upload")
-  public ResponseEntity uploadFile(final StorageDto storageDto) {
+  public ResponseEntity<Void> uploadFile(final StorageDto storageDto) {
 
     log.info("Request receive to upload file: {}", storageDto);
     if (Objects.nonNull(storageDto.getBucketName()) && Objects.nonNull(storageDto.getFolderPath())
         && Objects.nonNull(storageDto.getFiles()) && !storageDto.getFiles().isEmpty()) {
-      final var response = awsStorageService.upload(storageDto);
-      return ResponseEntity.ok(response);
+      awsStorageService.upload(storageDto);
+      return ResponseEntity.ok().build();
     } else {
       throw new AwsStorageException(
           "Bucket Name, File and Folder Path all parameters required to serve download");

--- a/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
@@ -6,7 +6,6 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -69,7 +68,8 @@ public class AwsStorageController {
    * @return Response entity with status code 200 and file to download
    */
   @GetMapping("/download")
-  public ResponseEntity<ByteArrayResource> downloadFile(@RequestParam("bucketName") final String bucketName,
+  public ResponseEntity<ByteArrayResource> downloadFile(
+      @RequestParam("bucketName") final String bucketName,
       @RequestParam("key") final String key) {
 
     if (Objects.nonNull(bucketName) && Objects.nonNull(key)) {
@@ -123,7 +123,7 @@ public class AwsStorageController {
       @RequestParam("folderPath") final String folderPath,
       @RequestParam(value = "sort", required = false) final String sort,
       @RequestParam(value = "includeCustomMetadata", defaultValue = "false")
-        final boolean includeCustomMetaData) {
+      final boolean includeCustomMetaData) {
 
     if (Objects.nonNull(bucketName) && Objects.nonNull(folderPath)) {
       log.info("Request receive to list files from bucket: {} and folder location: {}",

--- a/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -68,7 +69,7 @@ public class AwsStorageController {
    * @return Response entity with status code 200 and file to download
    */
   @GetMapping("/download")
-  public ResponseEntity downloadFile(@RequestParam("bucketName") final String bucketName,
+  public ResponseEntity<ByteArrayResource> downloadFile(@RequestParam("bucketName") final String bucketName,
       @RequestParam("key") final String key) {
 
     if (Objects.nonNull(bucketName) && Objects.nonNull(key)) {

--- a/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/controller/AwsStorageController.java
@@ -6,7 +6,6 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -22,13 +21,24 @@ import uk.nhs.hee.tis.common.upload.dto.StorageDto;
 import uk.nhs.hee.tis.common.upload.exception.AwsStorageException;
 import uk.nhs.hee.tis.common.upload.service.AwsStorageService;
 
+/**
+ * Controller to handle AWS S3 storage operations.
+ */
 @Slf4j
 @RestController
 @RequestMapping("/api/storage")
 public class AwsStorageController {
 
-  @Autowired
-  private AwsStorageService awsStorageService;
+  private final AwsStorageService awsStorageService;
+
+  /**
+   * Constructor for AwsStorageController.
+   *
+   * @param awsStorageService the AWS storage service
+   */
+  AwsStorageController(AwsStorageService awsStorageService) {
+    this.awsStorageService = awsStorageService;
+  }
 
   /**
    * API to upload file to s3.
@@ -111,7 +121,7 @@ public class AwsStorageController {
       @RequestParam("bucketName") final String bucketName,
       @RequestParam("folderPath") final String folderPath,
       @RequestParam(value = "sort", required = false) final String sort,
-      @RequestParam(value = "includeCustomMetadata", required = false)
+      @RequestParam(value = "includeCustomMetadata", defaultValue = "false")
         final boolean includeCustomMetaData) {
 
     if (Objects.nonNull(bucketName) && Objects.nonNull(folderPath)) {

--- a/src/main/java/uk/nhs/hee/tis/common/upload/service/AwsStorageService.java
+++ b/src/main/java/uk/nhs/hee/tis/common/upload/service/AwsStorageService.java
@@ -118,7 +118,8 @@ public class AwsStorageService {
             .metadata(metadata).contentLength(file.getSize()).build();
 
         log.info("uploading file: {} to bucket: {} with key: {}", file.getName(), bucketName, key);
-        return amazonS3.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        return amazonS3.putObject(request,
+            RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
       } catch (Exception e) {
         log.error("Failed to upload file: {} in bucket: {}", file.getOriginalFilename(), bucketName,
@@ -138,7 +139,8 @@ public class AwsStorageService {
     try {
       log.info("Download file: {} from bucket: {} with key: {}", storageDto.getKey(),
           storageDto.getBucketName(), storageDto.getKey());
-      GetObjectRequest request = GetObjectRequest.builder().bucket(storageDto.getBucketName()).key(storageDto.getKey()).build();
+      GetObjectRequest request = GetObjectRequest.builder().bucket(storageDto.getBucketName())
+          .key(storageDto.getKey()).build();
 
       try (ResponseInputStream<GetObjectResponse> s3Object = amazonS3.getObject(request)) {
         byte[] content = s3Object.readAllBytes();
@@ -333,7 +335,7 @@ public class AwsStorageService {
           ListObjectVersionsRequest.builder().bucket(bucket).prefix(key)
               .build());
       for (ObjectVersion version : versions.versions()) {
-        if (!version.isLatest()) {
+        if (Boolean.FALSE.equals(version.isLatest())) {
           amazonS3.deleteObject(
               DeleteObjectRequest.builder().bucket(bucket).key(key).versionId(version.versionId())
                   .build());
@@ -343,15 +345,15 @@ public class AwsStorageService {
   }
 
   private void createBucketIfNotExist(final String bucketName) {
-      try {
-        amazonS3.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
-        return;
-      } catch (NoSuchBucketException e) {
-        // expected
-      }
-      amazonS3.createBucket(CreateBucketRequest.builder().bucket(bucketName)
-            .build());
+    try {
+      amazonS3.headBucket(HeadBucketRequest.builder().bucket(bucketName).build());
+      return;
+    } catch (NoSuchBucketException e) {
+      // expected
     }
+    amazonS3.createBucket(CreateBucketRequest.builder().bucket(bucketName)
+        .build());
+  }
 
   private FileSummaryDto buildFileSummary(final S3Object summary, final String bucketName,
       final boolean includeCustomMetadata) {

--- a/src/test/java/uk/nhs/hee/tis/common/upload/service/AwsSnsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/common/upload/service/AwsSnsServiceTest.java
@@ -29,14 +29,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.model.AmazonSNSException;
-import com.amazonaws.services.sns.model.PublishRequest;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.SnsException;
 import uk.nhs.hee.tis.common.upload.dto.DeleteEventDto;
 import uk.nhs.hee.tis.common.upload.enumeration.DeleteType;
 
@@ -46,11 +46,11 @@ class AwsSnsServiceTest {
 
   private AwsSnsService awsSnsService;
 
-  private AmazonSNS snsClientMock;
+  private SnsClient snsClientMock;
 
   @BeforeEach
   void setup() {
-    snsClientMock = mock(AmazonSNS.class);
+    snsClientMock = mock(SnsClient.class);
     awsSnsService = new AwsSnsService(TOPIC_ARN, snsClientMock, new ObjectMapper());
   }
 
@@ -70,9 +70,9 @@ class AwsSnsServiceTest {
     verify(snsClientMock).publish(requestCaptor.capture());
 
     PublishRequest resultPubRequest = requestCaptor.getValue();
-    assertThat("Unexpected message.", resultPubRequest.getMessage(),
+    assertThat("Unexpected message.", resultPubRequest.message(),
         is(deleteEventJson.toString()));
-    assertThat("Unexpected topic Arn.", resultPubRequest.getTopicArn(), is(TOPIC_ARN));
+    assertThat("Unexpected topic Arn.", resultPubRequest.topicArn(), is(TOPIC_ARN));
   }
 
   @Test
@@ -82,8 +82,8 @@ class AwsSnsServiceTest {
     deleteEventDto.setKey("file-to-delete.json");
     deleteEventDto.setDeleteType(DeleteType.PARTIAL);
 
-    when(snsClientMock.publish(any())).thenThrow(
-        AmazonSNSException.class);
+    when(snsClientMock.publish(any(PublishRequest.class))).thenThrow(
+        SnsException.class);
     assertDoesNotThrow(() -> awsSnsService.publishSnsDeleteEventTopic(deleteEventDto));
   }
 }


### PR DESCRIPTION
1. We need to use the s3Client.headObject() method to retrieve the metadata from an S3 object.
2. When using HeadObjectResponse.metadata(), it returns the custom metadata, and the returned map is unmodifiable.
3. With AWS Java SDK v2, returning a pre-built SDK model directly is no longer appropriate.
4. About the endpoints & tests: 
    1) `/upload`: had been used in Admins-UI until the end of 2025. And it's also found in Revalidation Concern module, but Concern is not in use. I used a old version of Admins-UI for testing this endpoint.
    2) `/download`, `/delete`: only found in Revalidation Concern module. I used Postman for testing. 
    3) `/data`, `/list`: are using in Admins-UI.  And it's also found in Revalidation Concern module. I tested from Admins-UI.

TIS21-7808